### PR TITLE
feat: infer dual build type from package.json microsoft/TypeScript#54593

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,17 @@
 
 Node.js tool for building a TypeScript dual package.
 
-Inspired by https://github.com/microsoft/TypeScript/issues/49462.
+## Features
+
+* Bidirectional ESM <--> CJS dual builds inferred from the package.json `type`.
+* Correctly preserves module systems for `.mts` and `.cts` file extensions.
+* Only one package.json and tsconfig.json needed.
 
 ## Requirements
 
 * Node >= 16.19.0.
-* TypeScript, `npm i typescript`.
-* A `tsconfig.json` with `outDir` defined.
+* A package.json with `type` defined.
+* A tsconfig.json with `outDir` defined.
 
 ## Example
 
@@ -28,9 +32,7 @@ Then, given a `package.json` that defines `"type": "module"` and  a `tsconfig.js
 {
   "compilerOptions": {
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "declaration": true,
-    "esModuleInterop": true,
     "outDir": "dist",
     "strict": true,
   },
@@ -54,7 +56,7 @@ user@comp ~ $ npm run build
 
 If everything worked, you should have an ESM build inside of `dist` and a CJS build inside of `dist/cjs`. Now you can update your [`exports`](https://nodejs.org/api/packages.html#exports) to match the build output.
 
-It should work similarly for a CJS-first project. Except, your `tsconfig.json` may define `--module` and `--moduleResolution` differently, your package.json file would use `"type": "commonjs"`, and you'd want to pass `--target-extension .mjs`.
+It should work similarly for a CJS-first project. Except, your package.json file would use `"type": "commonjs"`.
 
 See the available [options](#options).
 
@@ -64,16 +66,16 @@ See the available [options](#options).
 The available options are limited, because you should define most of them inside your project's `tsconfig.json` file.
 
 * `--project, -p` The path to the project's configuration file. Defaults to `tsconfig.json`.
-* `--target-extension, -x` The desired target extension which determines the type of dual build. Defaults to `.cjs`.
+* `--pkg-dir, -k` The directory to start looking for a package.json file. Defaults to the cwd.
 
-You can run `duel --help` to get more info. Below is the output of that:
+You can run `duel --help` to get the same info. Below is the output of that:
 
 ```console
 Usage: duel [options]
 
 Options:
 --project, -p 		 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
---target-extension, -x 	 Sets the file extension for the dual build. [.cjs,.mjs]
+--pkg-dir, -k 		 The directory to start looking for a package.json file. Defaults to cwd.
 --help, -h 		 Print this message.
 ```
 
@@ -81,8 +83,8 @@ Options:
 
 These are definitely edge cases, and would only really come up if your project mixes file extensions. For example, if you have `.ts` files combined with `.mts`, and/or `.cts`. For most projects, things should just work as expected.
 
-As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using `tsc` while only using a **one package.json** file and **one tsconfig.json** file _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration.
+As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while only using **one package.json** file and **one tsconfig.json** file _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
 
-* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't. If you want to see one of my extended rants on this, check out this [comment](https://github.com/microsoft/TypeScript/pull/50985#issuecomment-1656991606). This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the files extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
+* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_ without using **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the files extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
 
 * If doing an `import type` across module systems, i.e. from `.mts` into `.cts`, or vice versa, you might encounter the compilation error ``error TS1452: 'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.``. This is a [known issue](https://github.com/microsoft/TypeScript/issues/49055) and TypeScript currently suggests installing the nightly build, i.e. `npm i typescript@next`.

--- a/README.md
+++ b/README.md
@@ -74,16 +74,16 @@ You can run `duel --help` to get the same info. Below is the output of that:
 Usage: duel [options]
 
 Options:
---project, -p 		 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
---pkg-dir, -k 		 The directory to start looking for a package.json file. Defaults to cwd.
---help, -h 		 Print this message.
+--project, -p 	 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+--pkg-dir, -k 	 The directory to start looking for a package.json file. Defaults to cwd.
+--help, -h 	 Print this message.
 ```
 
 ## Gotchas
 
 These are definitely edge cases, and would only really come up if your project mixes file extensions. For example, if you have `.ts` files combined with `.mts`, and/or `.cts`. For most projects, things should just work as expected.
 
-As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while only using **one package.json** file and **one tsconfig.json** file _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
+As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while using only **one package.json** file and **one tsconfig.json** file _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
 
 * Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_ without using **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the files extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
-        "@knighted/specifier": "^1.0.0-alpha.5",
+        "@knighted/specifier": "^1.0.0-rc.0",
         "glob": "^10.3.3",
         "read-pkg-up": "^10.0.0"
       },
@@ -2071,9 +2071,9 @@
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@knighted/specifier": {
-      "version": "1.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@knighted/specifier/-/specifier-1.0.0-alpha.5.tgz",
-      "integrity": "sha512-VGJ8OtGEmyeny63hYKAGutbL44duWDkHTycnwPQpCKzyhEZChwy7huXXLNH173yHMUBUAxpGsFoNh3Z+ykTpBw==",
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@knighted/specifier/-/specifier-1.0.0-rc.0.tgz",
+      "integrity": "sha512-7icdcZjBc+qrHxNdM8ErE4dnpuAhaVzxGwDnWff9BsA0UaRLrS+X9XcHLwzeViMaapWKNes3RxA8vz2b0u9d1w==",
       "dependencies": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/duel",
-      "version": "1.0.0-rc.0",
+      "version": "1.0.0-rc.1",
       "license": "MIT",
       "dependencies": {
         "@knighted/specifier": "^1.0.0-alpha.5",
-        "glob": "^10.3.3"
+        "glob": "^10.3.3",
+        "read-pkg-up": "^10.0.0"
       },
       "bin": {
         "duel": "dist/duel.js"
@@ -2135,8 +2136,7 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -2608,7 +2608,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -3053,8 +3052,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -3173,7 +3171,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3193,7 +3190,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
       "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
@@ -3205,7 +3201,6 @@
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -3269,14 +3264,12 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
     },
     "node_modules/is-core-module": {
       "version": "2.12.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
       "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -3433,7 +3426,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
       "integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
-      "dev": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -3479,7 +3471,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.3.tgz",
       "integrity": "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -3620,7 +3611,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
       "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
-      "dev": true,
       "dependencies": {
         "hosted-git-info": "^6.0.0",
         "is-core-module": "^2.8.1",
@@ -3635,7 +3625,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3647,7 +3636,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -3661,8 +3649,7 @@
     "node_modules/normalize-package-data/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -3736,7 +3723,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-7.0.0.tgz",
       "integrity": "sha512-kP+TQYAzAiVnzOlWOe0diD6L35s9bJh0SCn95PIbZFKrOYuIRQsQkeWEYxzVDuHTt9V9YqvYCJ2Qo4z9wdfZPw==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.21.4",
         "error-ex": "^1.3.2",
@@ -3869,7 +3855,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-8.0.0.tgz",
       "integrity": "sha512-Ajb9oSjxXBw0YyOiwtQ2dKbAA/vMnUPnY63XcCk+mXo0BwIdQEMgZLZiMWGttQHcUhUgbK0mH85ethMPKXxziw==",
-      "dev": true,
       "dependencies": {
         "@types/normalize-package-data": "^2.4.1",
         "normalize-package-data": "^5.0.0",
@@ -3887,7 +3872,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-10.0.0.tgz",
       "integrity": "sha512-jgmKiS//w2Zs+YbX039CorlkOp8FIVbSAN8r8GJHDsGlmNPXo+VeHkqAwCiQVTTx5/LwLZTcEw59z3DvcLbr0g==",
-      "dev": true,
       "dependencies": {
         "find-up": "^6.3.0",
         "read-pkg": "^8.0.0",
@@ -3904,7 +3888,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^7.1.0",
         "path-exists": "^5.0.0"
@@ -3920,7 +3903,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^6.0.0"
       },
@@ -3935,7 +3917,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^1.0.0"
       },
@@ -3950,7 +3931,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^4.0.0"
       },
@@ -3965,7 +3945,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -3974,7 +3953,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
       "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "dev": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -4194,7 +4172,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
-      "dev": true,
       "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -4203,14 +4180,12 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "dev": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "dev": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -4219,8 +4194,7 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.13",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
-      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
-      "dev": true
+      "integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w=="
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -4404,7 +4378,6 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
       "integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
-      "dev": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -4522,7 +4495,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
-      "dev": true,
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "TypeScript dual packages.",
   "type": "module",
   "main": "dist",
@@ -56,7 +56,8 @@
   },
   "dependencies": {
     "@knighted/specifier": "^1.0.0-alpha.5",
-    "glob": "^10.3.3"
+    "glob": "^10.3.3",
+    "read-pkg-up": "^10.0.0"
   },
   "prettier": {
     "arrowParens": "avoid",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "typescript": "^5.2.0-dev.20230727"
   },
   "dependencies": {
-    "@knighted/specifier": "^1.0.0-alpha.5",
+    "@knighted/specifier": "^1.0.0-rc.0",
     "glob": "^10.3.3",
     "read-pkg-up": "^10.0.0"
   },

--- a/src/init.js
+++ b/src/init.js
@@ -48,12 +48,12 @@ const init = async args => {
     log('Usage: duel [options]\n')
     log('Options:')
     log(
-      "--project, -p \t\t Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.",
+      "--project, -p \t Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.",
     )
     log(
-      '--pkg-dir, -k \t\t The directory to start looking for a package.json file. Defaults to cwd.',
+      '--pkg-dir, -k \t The directory to start looking for a package.json file. Defaults to cwd.',
     )
-    log('--help, -h \t\t Print this message.')
+    log('--help, -h \t Print this message.')
   } else {
     const { project, 'target-extension': targetExt, 'pkg-dir': pkgDir } = parsed
     let configPath = resolve(project)

--- a/src/init.js
+++ b/src/init.js
@@ -1,11 +1,13 @@
+import { cwd } from 'node:process'
 import { parseArgs } from 'node:util'
 import { resolve, join, dirname } from 'node:path'
 import { stat, readFile } from 'node:fs/promises'
 
+import { readPackageUp } from 'read-pkg-up'
+
 import { logError, log } from './util.js'
 
 const init = async args => {
-  const validTargetExts = ['.cjs', '.mjs']
   let parsed = null
 
   try {
@@ -20,7 +22,12 @@ const init = async args => {
         'target-extension': {
           type: 'string',
           short: 'x',
-          default: '.cjs',
+          default: '',
+        },
+        'pkg-dir': {
+          type: 'string',
+          short: 'k',
+          default: cwd(),
         },
         help: {
           type: 'boolean',
@@ -44,18 +51,27 @@ const init = async args => {
       "--project, -p \t\t Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.",
     )
     log(
-      '--target-extension, -x \t Sets the file extension for the dual build. [.cjs,.mjs]',
+      '--pkg-dir, -k \t\t The directory to start looking for a package.json file. Defaults to cwd.',
     )
     log('--help, -h \t\t Print this message.')
   } else {
-    const { project, 'target-extension': targetExt } = parsed
+    const { project, 'target-extension': targetExt, 'pkg-dir': pkgDir } = parsed
     let configPath = resolve(project)
     let stats = null
+    let pkg = null
 
-    if (!validTargetExts.includes(targetExt)) {
+    if (targetExt) {
       logError(
-        `Invalid arg '${targetExt}' for --target-extension. Must be one of ${validTargetExts.toString()}`,
+        '--target-extension is deprecated. Define "type" in your package.json instead and the dual build will be inferred from that.',
       )
+
+      return false
+    }
+
+    pkg = await readPackageUp({ cwd: pkgDir })
+
+    if (!pkg) {
+      logError('No package.json file found.')
 
       return false
     }
@@ -106,11 +122,10 @@ const init = async args => {
       const projectDir = dirname(configPath)
 
       return {
+        pkg,
         tsconfig,
-        targetExt,
         projectDir,
         configPath,
-        absoluteOutDir: resolve(projectDir, tsconfig.compilerOptions.outDir),
       }
     }
   }

--- a/test/__fixtures__/cjsProject/package.json
+++ b/test/__fixtures__/cjsProject/package.json
@@ -5,7 +5,7 @@
     ".": {
       "import": {
         "types": "./dist/mjs/index.d.mts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/mjs/index.mjs"
       },
       "require": {
         "types": "./dist/index.d.ts",

--- a/test/__fixtures__/cjsProject/src/index.ts
+++ b/test/__fixtures__/cjsProject/src/index.ts
@@ -30,8 +30,9 @@ class UserAccount {
 
 const getUser = async () => {
   const { esm } = await import('./esm.mjs')
+  const user = new UserAccount("Murphy", 1, mod, esm, cjs)
 
-  return new UserAccount("Murphy", 1, mod, esm, cjs)
+  return user
 }
 
 getUser()

--- a/test/__fixtures__/esmProject/src/index.ts
+++ b/test/__fixtures__/esmProject/src/index.ts
@@ -1,16 +1,14 @@
-import { mod } from "./folder/module.js";
-import { esm } from './esm.mjs'
+import { mod } from "./folder/module.js"
 import { cjs } from './cjs.cjs'
 
-import type { Mod } from "./folder/module.js";
-import type { ESM } from './esm.mjs'
-import type { CJS } from "./cjs.cjs";
+import type { Mod } from "./folder/module.js"
+import type { CJS } from "./cjs.cjs"
 
 interface User {
   name: string;
   id: number;
   mod: Mod;
-  esm: ESM;
+  esm: any;
   cjs: CJS;
 }
 
@@ -18,10 +16,10 @@ class UserAccount {
   name: string;
   id: number;
   mod: Mod;
-  esm: ESM;
+  esm: any;
   cjs: CJS;
 
-  constructor(name: string, id: number, mod: Mod, esm: ESM, cjs: CJS) {
+  constructor(name: string, id: number, mod: Mod, esm: any, cjs: CJS) {
     this.name = name;
     this.id = id;
     this.mod = mod;
@@ -30,8 +28,15 @@ class UserAccount {
   }
 }
 
-const user: User = new UserAccount("Murphy", 1, mod, esm, cjs);
+const getUser = async () => {
+  const { esm } = await import('./esm.mjs')
+  const user = new UserAccount("Murphy", 1, mod, esm, cjs)
+
+  return user
+}
+
+getUser()
 
 export type { User }
 
-export { user }
+export { getUser }

--- a/test/__fixtures__/esmProject/tsconfig.json
+++ b/test/__fixtures__/esmProject/tsconfig.json
@@ -2,11 +2,10 @@
   "compilerOptions": {
     "target": "ESNext",
     "module": "NodeNext",
-    "moduleResolution": "NodeNext",
     "declaration": true,
-    "strict": true,
+    "strict": false,
     "outDir": "dist",
-    "lib": ["ES2015"]
+    "lib": ["DOM", "ES2015"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
BREAKING CHANGE: deprecates --target-extension

* Adds `--pkg-dir` in place of `--target-extension`.
* Infers the dual build target from the package.json `type` field.
* Updates the README.
* Updates dependencies.