### PR TITLE
feat: --dirs option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ These are definitely edge cases, and would only really come up if your project m
 
 * If doing an `import type` across module systems, i.e. from `.mts` into `.cts`, or vice versa, you might encounter the compilation error ``error TS1452: 'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.``. This is a [known issue](https://github.com/microsoft/TypeScript/issues/49055) and TypeScript currently suggests installing the nightly build, i.e. `npm i typescript@next`.
 
-* If running `duel` with your project's package.json file open in your editor, you may temporarilly see the content replaced. This is because `duel` dynamically creates a new package.json using the `type` necessary for the dual build. Your original package.json will be restored after the build completes.
+* If running `duel` with your project's package.json file open in your editor, you may temporarily see the content replaced. This is because `duel` dynamically creates a new package.json using the `type` necessary for the dual build. Your original package.json will be restored after the build completes.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Node.js tool for building a TypeScript dual package.
 ## Requirements
 
 * Node >= 16.19.0.
-* A package.json with `type` defined.
 * A tsconfig.json with `outDir` defined.
 
 ## Example
@@ -31,10 +30,9 @@ Then, given a `package.json` that defines `"type": "module"` and  a `tsconfig.js
 ```json
 {
   "compilerOptions": {
-    "module": "NodeNext",
     "declaration": true,
-    "outDir": "dist",
-    "strict": true,
+    "module": "NodeNext",
+    "outDir": "dist"
   },
   "include": ["src"]
 }
@@ -99,12 +97,14 @@ Options:
 
 These are definitely edge cases, and would only really come up if your project mixes file extensions. For example, if you have `.ts` files combined with `.mts`, and/or `.cts`. For most projects, things should just work as expected.
 
-As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while using only **one package.json** file and **one tsconfig.json** file, _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
-
 * This is going to work best if your CJS-first project uses file extensions in their _relative_ specifiers. This is completely acceptable in CJS projects, and [required in ESM projects](https://nodejs.org/api/esm.html#import-specifiers). This package makes no attempt to rewrite bare specifiers, or remap any relative specifiers to a directory index.
 
-* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_ without requiring **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the file's extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
+* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_, without requiring **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the file's extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
 
 * If doing an `import type` across module systems, i.e. from `.mts` into `.cts`, or vice versa, you might encounter the compilation error ``error TS1452: 'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.``. This is a [known issue](https://github.com/microsoft/TypeScript/issues/49055) and TypeScript currently suggests installing the nightly build, i.e. `npm i typescript@next`.
 
 * If running `duel` with your project's package.json file open in your editor, you may temporarilly see the content replaced. This is because `duel` dynamically creates a new package.json using the `type` necessary for the dual build. Your original package.json will be restored after the build completes.
+
+## Notes
+
+As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while using only **one package.json** file and **one tsconfig.json** file, _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers. The downside of their decisions, and the fact that npm does not support using alternative names for the package.json file, is that this project can not run both builds in parallel.

--- a/README.md
+++ b/README.md
@@ -56,10 +56,21 @@ user@comp ~ $ npm run build
 
 If everything worked, you should have an ESM build inside of `dist` and a CJS build inside of `dist/cjs`. Now you can update your [`exports`](https://nodejs.org/api/packages.html#exports) to match the build output.
 
-It should work similarly for a CJS-first project. Except, your package.json file would use `"type": "commonjs"`.
+It should work similarly for a CJS-first project. Except, your package.json file would use `"type": "commonjs"` and the dual build directory is in `dist/esm`.
+
+### Output directories
+
+If you prefer to have both builds in directories inside of your defined `outDir`, you can use the `--dirs` option.
+
+```json
+"scripts": {
+  "build": "duel --dirs"
+}
+```
+
+Assuming an `outDir` of `dist`, running the above will create `dist/esm` and `dist/cjs` directories.
 
 See the available [options](#options).
-
 
 ## Options
 
@@ -67,6 +78,7 @@ The available options are limited, because you should define most of them inside
 
 * `--project, -p` The path to the project's configuration file. Defaults to `tsconfig.json`.
 * `--pkg-dir, -k` The directory to start looking for a package.json file. Defaults to the cwd.
+* `--dirs, -d` Outputs both builds to directories inside of `outDir`. Defalts to `false`.
 
 You can run `duel --help` to get the same info. Below is the output of that:
 
@@ -74,17 +86,25 @@ You can run `duel --help` to get the same info. Below is the output of that:
 Usage: duel [options]
 
 Options:
---project, -p 	 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
---pkg-dir, -k 	 The directory to start looking for a package.json file. Defaults to cwd.
---help, -h 	 Print this message.
+Usage: duel [options]
+
+Options:
+--project, -p [path] 	 Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.
+--pkg-dir, -k [path] 	 The directory to start looking for a package.json file. Defaults to cwd.
+--dirs, -d 		 Output both builds to directories inside of outDir. [esm, cjs].
+--help, -h 		 Print this message.
 ```
 
 ## Gotchas
 
 These are definitely edge cases, and would only really come up if your project mixes file extensions. For example, if you have `.ts` files combined with `.mts`, and/or `.cts`. For most projects, things should just work as expected.
 
-As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while using only **one package.json** file and **one tsconfig.json** file _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
+As far as I can tell, `duel` is one (if not the only) way to get a correct dual package build using only `tsc` while using only **one package.json** file and **one tsconfig.json** file, _and also_ preserving module system by file extension. The Microsoft backed TypeScript team [keep](https://github.com/microsoft/TypeScript/issues/54593) [talking](https://github.com/microsoft/TypeScript/pull/54546) about dual build support, but their philosophy is mainly one of self perseverance, rather than collaboration. For instance, they continue to refuse to rewrite specifiers.
 
-* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_ without using **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the files extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
+* This is going to work best if your CJS-first project uses file extensions in their _relative_ specifiers. This is completely acceptable in CJS projects, and [required in ESM projects](https://nodejs.org/api/esm.html#import-specifiers). This package makes no attempt to rewrite bare specifiers, or remap any relative specifiers to a directory index.
+
+* Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_ without requiring **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the file's extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
 
 * If doing an `import type` across module systems, i.e. from `.mts` into `.cts`, or vice versa, you might encounter the compilation error ``error TS1452: 'resolution-mode' assertions are only supported when `moduleResolution` is `node16` or `nodenext`.``. This is a [known issue](https://github.com/microsoft/TypeScript/issues/49055) and TypeScript currently suggests installing the nightly build, i.e. `npm i typescript@next`.
+
+* If running `duel` with your project's package.json file open in your editor, you may temporarilly see the content replaced. This is because `duel` dynamically creates a new package.json using the `type` necessary for the dual build. Your original package.json will be restored after the build completes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/duel",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "@knighted/specifier": "^1.0.0-rc.0",
@@ -17,7 +17,7 @@
         "duel": "dist/duel.js"
       },
       "devDependencies": {
-        "babel-dual-package": "^1.0.0-rc.5",
+        "babel-dual-package": "^1.0.0",
         "c8": "^8.0.1",
         "eslint": "^8.45.0",
         "eslint-plugin-n": "^16.0.1",
@@ -2201,9 +2201,9 @@
       "dev": true
     },
     "node_modules/babel-dual-package": {
-      "version": "1.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/babel-dual-package/-/babel-dual-package-1.0.0-rc.5.tgz",
-      "integrity": "sha512-wzZQVpJB9e6aO+Zld6nwekFiEMFDGRlnSM1SNO5Qjuo2/VG4sx51ypqBAxBFKWdzSuKbZMljqTEdBg/3RybQlw==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/babel-dual-package/-/babel-dual-package-1.0.0.tgz",
+      "integrity": "sha512-+IgSFFXgCRXxIbG6WcSF+CnrIwUW+NHyheasP1n+jdVk8ge3QKWOP9xZDH0RYE1ATVFGk6aHULZeZDV/zkgHEw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.22.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "TypeScript dual packages.",
   "type": "module",
   "main": "dist",
@@ -47,7 +47,7 @@
     "typescript": ">=4.0.0"
   },
   "devDependencies": {
-    "babel-dual-package": "^1.0.0-rc.5",
+    "babel-dual-package": "^1.0.0",
     "c8": "^8.0.1",
     "eslint": "^8.45.0",
     "eslint-plugin-n": "^16.0.1",

--- a/src/init.js
+++ b/src/init.js
@@ -29,6 +29,11 @@ const init = async args => {
           short: 'k',
           default: cwd(),
         },
+        dirs: {
+          type: 'boolean',
+          short: 'd',
+          default: false,
+        },
         help: {
           type: 'boolean',
           short: 'h',
@@ -48,14 +53,15 @@ const init = async args => {
     log('Usage: duel [options]\n')
     log('Options:')
     log(
-      "--project, -p \t Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.",
+      "--project, -p [path] \t Compile the project given the path to its configuration file, or to a folder with a 'tsconfig.json'.",
     )
     log(
-      '--pkg-dir, -k \t The directory to start looking for a package.json file. Defaults to cwd.',
+      '--pkg-dir, -k [path] \t The directory to start looking for a package.json file. Defaults to cwd.',
     )
-    log('--help, -h \t Print this message.')
+    log('--dirs, -d \t\t Output both builds to directories inside of outDir. [esm, cjs].')
+    log('--help, -h \t\t Print this message.')
   } else {
-    const { project, 'target-extension': targetExt, 'pkg-dir': pkgDir } = parsed
+    const { project, 'target-extension': targetExt, 'pkg-dir': pkgDir, dirs } = parsed
     let configPath = resolve(project)
     let stats = null
     let pkg = null
@@ -123,6 +129,7 @@ const init = async args => {
 
       return {
         pkg,
+        dirs,
         tsconfig,
         projectDir,
         configPath,

--- a/test/__fixtures__/esmProject/script.js
+++ b/test/__fixtures__/esmProject/script.js
@@ -1,3 +1,0 @@
-//import * as cjs from './dist/cjs/cjs.cjs'
-
-require('./dist/cjs/cjs.cjs')

--- a/test/__fixtures__/esmProject/src/cjs.cts
+++ b/test/__fixtures__/esmProject/src/cjs.cts
@@ -1,27 +1,3 @@
-/*
-import type { ESM } from './esm.mjs' assert { 'resolution-mode': 'import' };
-
-interface CJS {
-  cjs: boolean,
-  esm: ESM;
-}
-
-const func = async () => {
-  const { esm } = await import('./esm.mjs')
-
-  const cjs: CJS = {
-    cjs: true,
-    esm
-  }
-
-  return cjs
-}
-
-export { func }
-
-export type { CJS }
-*/
-
 import MagicString from "magic-string"
 
 interface CJS {

--- a/test/__fixtures__/project/package.json
+++ b/test/__fixtures__/project/package.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      },
+      "default": "./dist/esm/index.js"
+    },
+    "./package.json": "./package.json"
+  }
+}

--- a/test/__fixtures__/project/src/cjs.cts
+++ b/test/__fixtures__/project/src/cjs.cts
@@ -1,0 +1,39 @@
+/*
+import type { ESM } from './esm.mjs' assert { 'resolution-mode': 'import' };
+
+interface CJS {
+  cjs: boolean,
+  esm: ESM;
+}
+
+const func = async () => {
+  const { esm } = await import('./esm.mjs')
+
+  const cjs: CJS = {
+    cjs: true,
+    esm
+  }
+
+  return cjs
+}
+
+export { func }
+
+export type { CJS }
+*/
+
+import MagicString from "magic-string"
+
+interface CJS {
+  cjs: boolean;
+  magic: MagicString;
+}
+
+const cjs: CJS = {
+  cjs: true,
+  magic: new MagicString('magic')
+}
+
+export { cjs }
+
+export type { CJS }

--- a/test/__fixtures__/project/src/cjs.cts
+++ b/test/__fixtures__/project/src/cjs.cts
@@ -1,27 +1,3 @@
-/*
-import type { ESM } from './esm.mjs' assert { 'resolution-mode': 'import' };
-
-interface CJS {
-  cjs: boolean,
-  esm: ESM;
-}
-
-const func = async () => {
-  const { esm } = await import('./esm.mjs')
-
-  const cjs: CJS = {
-    cjs: true,
-    esm
-  }
-
-  return cjs
-}
-
-export { func }
-
-export type { CJS }
-*/
-
 import MagicString from "magic-string"
 
 interface CJS {

--- a/test/__fixtures__/project/src/esm.mts
+++ b/test/__fixtures__/project/src/esm.mts
@@ -1,0 +1,9 @@
+interface ESM {
+  esm: boolean;
+}
+
+export const esm: ESM = {
+  esm: true
+}
+
+export type { ESM }

--- a/test/__fixtures__/project/src/folder/another.mts
+++ b/test/__fixtures__/project/src/folder/another.mts
@@ -1,0 +1,9 @@
+interface ESM {
+  esm: boolean;
+}
+
+export const esm: ESM = {
+  esm: true
+}
+
+export type { ESM }

--- a/test/__fixtures__/project/src/folder/module.ts
+++ b/test/__fixtures__/project/src/folder/module.ts
@@ -1,0 +1,20 @@
+import MagicString from "magic-string";
+import { cjs } from "../cjs.cjs";
+
+import type { CJS } from "../cjs.cjs";
+
+interface Mod {
+  prop: string;
+  cjs: CJS
+}
+
+const mod: Mod = {
+  prop: 'foobar',
+  cjs: {
+    cjs: true,
+    magic: new MagicString('module')
+  }
+}
+
+export { mod, cjs }
+export type { Mod }

--- a/test/__fixtures__/project/src/index.ts
+++ b/test/__fixtures__/project/src/index.ts
@@ -1,0 +1,42 @@
+import { mod } from "./folder/module.js"
+import { cjs } from './cjs.cjs'
+
+import type { Mod } from "./folder/module.js"
+import type { CJS } from "./cjs.cjs"
+
+interface User {
+  name: string;
+  id: number;
+  mod: Mod;
+  esm: any;
+  cjs: CJS;
+}
+
+class UserAccount {
+  name: string;
+  id: number;
+  mod: Mod;
+  esm: any;
+  cjs: CJS;
+
+  constructor(name: string, id: number, mod: Mod, esm: any, cjs: CJS) {
+    this.name = name;
+    this.id = id;
+    this.mod = mod;
+    this.esm = esm;
+    this.cjs = cjs;
+  }
+}
+
+const getUser = async () => {
+  const { esm } = await import('./esm.mjs')
+  const user = new UserAccount("Murphy", 1, mod, esm, cjs)
+
+  return user
+}
+
+getUser()
+
+export type { User }
+
+export { getUser }

--- a/test/__fixtures__/project/tsconfig.json
+++ b/test/__fixtures__/project/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "NodeNext",
+    "outDir": "dist",
+    "declaration": true,
+    "strict": false,
+    "lib": ["DOM", "ES2015"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
* Adds `--dirs` option.
* Updates dependency `babel-dual-package`.
* Updates README.

BREAKING CHANGE:

* Renames the dual build dir for CJS-first projects from `mjs` to `esm`. Update your project's `exports` before publishing after building with `duel`.