### PR TITLE
chore: peer deps.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/duel",
-      "version": "1.0.0-rc.9",
+      "version": "1.0.0-rc.10",
       "license": "MIT",
       "dependencies": {
         "@knighted/specifier": "^1.0.0-rc.1",
@@ -30,7 +30,7 @@
         "node": ">=16.19.0"
       },
       "peerDependencies": {
-        "typescript": ">=4.0.0 || >=4.8.0-dev || >=4.9.0-dev || >=5.0.0-dev || >=5.1.0-dev || >=5.2.0-dev"
+        "typescript": ">=4.0.0 || >=4.9.0-dev || >=5.2.0-dev || >=5.3.0-dev"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.9",
+  "version": "1.0.0-rc.10",
   "description": "TypeScript dual packages.",
   "type": "module",
   "main": "dist",
@@ -44,7 +44,7 @@
     "url": "https://github.com/knightedcodemonkey/duel/issues"
   },
   "peerDependencies": {
-    "typescript": ">=4.0.0 || >=4.8.0-dev || >=4.9.0-dev || >=5.0.0-dev || >=5.1.0-dev || >=5.2.0-dev"
+    "typescript": ">=4.0.0 || >=4.9.0-dev || >=5.2.0-dev || >=5.3.0-dev"
   },
   "devDependencies": {
     "@types/node": "^20.4.6",

--- a/src/duel.js
+++ b/src/duel.js
@@ -133,7 +133,7 @@ const duel = async args => {
          * @see https://github.com/github/gitignore/blob/main/Node.gitignore
          */
         filter: src =>
-          !/logs|pids|lib-cov|coverage|bower_components|build|dist|jspm_packages|web_modules|out|\.next|\.tsbuildinfo|\.npm|\.node_repl_history|\.tgz|\.yarn|\.pnp|\.nyc_output|\.grunt/i.test(
+          !/logs|pids|lib-cov|coverage|bower_components|build|dist|jspm_packages|web_modules|out|\.next|\.tsbuildinfo|\.npm|\.node_repl_history|\.tgz|\.yarn|\.pnp|\.nyc_output|\.grunt|\.DS_Store/i.test(
             src,
           ),
       })


### PR DESCRIPTION
* Add another dir to the ignore list when running in parallel.
* Reduce peer deps to the last two for each major version >= 4.