### PR TITLE
ci: set dist tag from release tag.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,4 +33,5 @@ jobs:
         uses: JS-DevTools/npm-publish@v2.1.0
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}
+          tag: ${{ contains(github.ref, '-') && 'next' || 'latest' }}
           access: public

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Node.js tool for building a TypeScript dual package.
 First, install this package to create the `duel` executable inside your `node_modules/.bin` directory.
 
 ```console
-user@comp ~ $ npm i @knighted/duel
+user@comp ~ $ npm i @knighted/duel --save-dev
 ```
 
 Then, given a `package.json` that defines `"type": "module"` and  a `tsconfig.json` file that looks something like the following:
@@ -86,7 +86,7 @@ The available options are limited, because you should define most of them inside
 
 * `--project, -p` The path to the project's configuration file. Defaults to `tsconfig.json`.
 * `--pkg-dir, -k` The directory to start looking for a package.json file. Defaults to the cwd.
-* `--dirs, -d` Outputs both builds to directories inside of `outDir`. Defalts to `false`.
+* `--dirs, -d` Outputs both builds to directories inside of `outDir`. Defaults to `false`.
 * `--parallel, -l` Run the builds in parallel. Defaults to `false`.
 
 You can run `duel --help` to get the same info. Below is the output of that:
@@ -106,7 +106,7 @@ Options:
 
 These are definitely edge cases, and would only really come up if your project mixes file extensions. For example, if you have `.ts` files combined with `.mts`, and/or `.cts`. For most projects, things should just work as expected.
 
-* This is going to work best if your CJS-first project uses file extensions in their _relative_ specifiers. This is completely acceptable in CJS projects, and [required in ESM projects](https://nodejs.org/api/esm.html#import-specifiers). This package makes no attempt to rewrite bare specifiers, or remap any relative specifiers to a directory index.
+* This is going to work best if your CJS-first project uses file extensions in _relative_ specifiers. This is completely acceptable in CJS projects, and [required in ESM projects](https://nodejs.org/api/esm.html#import-specifiers). This package makes no attempt to rewrite bare specifiers, or remap any relative specifiers to a directory index.
 
 * Unfortunately, TypeScript doesn't really build [dual packages](https://nodejs.org/api/packages.html#dual-commonjses-module-packages) very well in regards to preserving module system by file extension. For instance, there doesn't appear to be a way to convert an arbitrary `.ts` file into another module system, _while also preserving the module system of `.mts` and `.cts` files_, without requiring **multiple** package.json files. In my opinion, the `tsc` compiler is fundamentally broken in this regard, and at best is enforcing usage patterns it shouldn't.  This is only mentioned for transparency, `duel` will correct for this and produce files with the module system you would expect based on the file's extension, so that it works with [how Node.js determines module systems](https://nodejs.org/api/packages.html#determining-module-system).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@knighted/duel",
-      "version": "1.0.0-rc.13",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@knighted/specifier": "^1.0.0",
@@ -25,7 +25,7 @@
         "eslint": "^8.45.0",
         "eslint-plugin-n": "^16.0.1",
         "prettier": "^3.0.1",
-        "typescript": "^5.2.0-dev.20230727",
+        "typescript": "^5.3.0-dev.20230906",
         "vite": "^4.4.8"
       },
       "engines": {
@@ -4963,9 +4963,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.0-dev.20230728",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.0-dev.20230728.tgz",
-      "integrity": "sha512-pI6gdSexHd/ESfy6Vwmd6bdId1UIYl1fkE8d2o/n/frQCeD6oupH93WTh0syCk3mYMpnx++flvR1X2WHJS1oVg==",
+      "version": "5.3.0-dev.20230906",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.0-dev.20230906.tgz",
+      "integrity": "sha512-7dCmQgfQ4i38daoPCCert+rM6gLxBpxRdjncJkHkJV4CWvNZsRX+RVTusojkqGAtW9vqB0+/8iDH6CZ0PDxghg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knighted/duel",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0",
   "description": "TypeScript dual packages.",
   "type": "module",
   "main": "dist",
@@ -53,7 +53,7 @@
     "eslint": "^8.45.0",
     "eslint-plugin-n": "^16.0.1",
     "prettier": "^3.0.1",
-    "typescript": "^5.2.0-dev.20230727",
+    "typescript": "^5.3.0-dev.20230906",
     "vite": "^4.4.8"
   },
   "dependencies": {


### PR DESCRIPTION
* Set npm dist tag based on release tag format.
* Fix README typos.
* Update `typescript` dev dependency.
* Bump to v1.0.0.